### PR TITLE
New iOS client features

### DIFF
--- a/client/mobileClient/MobileClient/ios/MobileClient.xcodeproj/project.pbxproj
+++ b/client/mobileClient/MobileClient/ios/MobileClient.xcodeproj/project.pbxproj
@@ -364,6 +364,11 @@
 					};
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = R7MRW44HVY;
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};

--- a/client/mobileClient/MobileClient/ios/MobileClient/Info.plist
+++ b/client/mobileClient/MobileClient/ios/MobileClient/Info.plist
@@ -29,6 +29,10 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/client/mobileClient/MobileClient/ios/MobileClient/RNAudioPlayerURL.m
+++ b/client/mobileClient/MobileClient/ios/MobileClient/RNAudioPlayerURL.m
@@ -4,6 +4,8 @@
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 
+@import MediaPlayer;
+
 @implementation RNAudioPlayerURL
 
 @synthesize bridge = _bridge;
@@ -17,6 +19,7 @@ RCT_EXPORT_METHOD(initWithURL:(NSString *)url){
   self.audioPlayer = [AVPlayer playerWithPlayerItem:self.audioItem];
 
   [self setBackgroundAudio];
+  [self registerRemoteControlEvents];
 
   [[NSNotificationCenter defaultCenter]
   	addObserver:self selector:@selector(playerItemDidReachEnd:) name:AVPlayerItemDidPlayToEndTimeNotification object:self.audioItem];
@@ -54,6 +57,29 @@ RCT_EXPORT_METHOD(seekToTime:(nonnull NSNumber *)toTime){
   if (categoryError) {
     NSLog(@"Error setting category!");
   }
+}
+
+-(void)registerRemoteControlEvents{
+  MPRemoteCommandCenter *controlCenter = [MPRemoteCommandCenter sharedCommandCenter];
+  [controlCenter.playCommand addTarget:self action:@selector(receivedPlayCommand:)];
+  [controlCenter.pauseCommand addTarget:self action:@selector(receivedPauseCommand:)];
+  controlCenter.stopCommand.enabled = NO;
+  controlCenter.nextTrackCommand.enabled = NO;
+  controlCenter.previousTrackCommand.enabled = NO;
+}
+
+- (void)receivedPlayCommand:(MPRemoteCommand *)event{
+  [self play];
+}
+
+- (void)receivedPauseCommand:(MPRemoteCommand *)event{
+  [self pause];
+}
+
+- (void)unregisterRemoteControlEvents{
+  MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+  [commandCenter.playCommand removeTarget:self];
+  [commandCenter.pauseCommand removeTarget:self];
 }
 
 @end

--- a/client/mobileClient/MobileClient/ios/MobileClient/RNAudioPlayerURL.m
+++ b/client/mobileClient/MobileClient/ios/MobileClient/RNAudioPlayerURL.m
@@ -15,6 +15,9 @@ RCT_EXPORT_METHOD(initWithURL:(NSString *)url){
   NSURL *soundUrl = [[NSURL alloc] initWithString:url];
   self.audioItem = [AVPlayerItem playerItemWithURL:soundUrl];
   self.audioPlayer = [AVPlayer playerWithPlayerItem:self.audioItem];
+
+  [self setBackgroundAudio];
+
   [[NSNotificationCenter defaultCenter]
   	addObserver:self selector:@selector(playerItemDidReachEnd:) name:AVPlayerItemDidPlayToEndTimeNotification object:self.audioItem];
 }
@@ -41,6 +44,16 @@ RCT_EXPORT_METHOD(pause){
 
 RCT_EXPORT_METHOD(seekToTime:(nonnull NSNumber *)toTime){
 	[self.audioPlayer seekToTime: CMTimeMakeWithSeconds([toTime floatValue], NSEC_PER_SEC)];
+}
+
+- (void)setBackgroundAudio {
+  NSError *categoryError = nil;
+  [[AVAudioSession sharedInstance]
+   setCategory:AVAudioSessionCategoryPlayback
+   error:&categoryError];
+  if (categoryError) {
+    NSLog(@"Error setting category!");
+  }
 }
 
 @end


### PR DESCRIPTION
- Active stream will continue playing when client is backgrounded
  - Resolves #35 
- Stream can be controlled from the iOS control center
  - Play/pause
- Code courtesy of [jhabdas/lumpen-radio](https://github.com/jhabdas/lumpen-radio) and brentvatne/react-native-video#41
  - Figuring out Obj-C, however, was courtesy of me; as pointed out, the code isn't quite copy-and-paste-able.